### PR TITLE
AfformScanner - Allow loading bare forms

### DIFF
--- a/core/Civi/Api4/Action/Afform/Revert.php
+++ b/core/Civi/Api4/Action/Afform/Revert.php
@@ -13,7 +13,7 @@ class Revert extends Get {
 
     parent::_run($result);
 
-    $files = [\CRM_Afform_AfformScanner::METADATA_FILE, 'aff.html'];
+    $files = [\CRM_Afform_AfformScanner::METADATA_FILE, \CRM_Afform_AfformScanner::LAYOUT_FILE];
 
     foreach ($result as $afform) {
       foreach ($files as $file) {

--- a/mock/ang/afformExamplepage.aff.html
+++ b/mock/ang/afformExamplepage.aff.html
@@ -1,2 +1,3 @@
 <div>Hello {{routeParams.name}}.</div>
 <div>The foo says "<span fakelib-foo/>".</div>
+<div>The bare file says "<span fakelib-bare-file/>"</div>

--- a/mock/ang/afformExamplepage.aff.json
+++ b/mock/ang/afformExamplepage.aff.json
@@ -1,1 +1,1 @@
-{"server_route": "civicrm/example-page", "requires":["fakelibFoo"]}
+{"server_route": "civicrm/example-page", "requires":["fakelibFoo", "fakelibBareFile"]}

--- a/mock/ang/fakelibBareFile.aff.html
+++ b/mock/ang/fakelibBareFile.aff.html
@@ -1,0 +1,1 @@
+<em>This is just an HTML file without any metadata.</em>

--- a/mock/ang/fakelibFoo.aff.html
+++ b/mock/ang/fakelibFoo.aff.html
@@ -1,1 +1,1 @@
-the foo bar stuff
+<em>the foo bar stuff</em>

--- a/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/mock/tests/phpunit/api/v4/AfformTest.php
@@ -37,45 +37,56 @@ class api_v4_AfformTest extends \PHPUnit_Framework_TestCase implements HeadlessI
     parent::tearDown();
   }
 
+  public function getBasicDirectives() {
+    return [
+      ['afformExamplepage', ['title' => '', 'description' => '', 'server_route' => 'civicrm/example-page']],
+      ['fakelibBareFile', ['title' => '', 'description' => '']],
+      ['fakelibFoo', ['title' => '', 'description' => '']],
+    ];
+  }
+
   /**
    * This takes the bundled `examplepage` and performs some API calls on it.
+   * @dataProvider getBasicDirectives
    */
-  public function testGetUpdateRevert() {
-    Civi\Api4\Afform::revert()->addWhere('name', '=', 'afformExamplepage')->execute();
+  public function testGetUpdateRevert($directiveName, $originalMetadata) {
+    $get = function($arr, $key) {
+      return isset($arr[$key]) ? $arr[$key] : NULL;
+    };
+
+    Civi\Api4\Afform::revert()->addWhere('name', '=', $directiveName)->execute();
 
     $message = 'The initial Afform.get should return default data';
-    $result = Civi\Api4\Afform::get()->addWhere('name', '=', 'afformExamplepage')->execute();
-    $result->indexBy('name');
-    $b = (array) $result;
-    $this->assertEquals('afformExamplepage', $result['afformExamplepage']['name'], $message);
-    $this->assertEquals('', $result['afformExamplepage']['title'], $message);
-    $this->assertEquals('', $result['afformExamplepage']['description'], $message);
-    $this->assertEquals('civicrm/example-page', $result['afformExamplepage']['server_route'], $message);
-    $this->assertTrue(is_array($result['afformExamplepage']['layout']), $message);
+    $result = Civi\Api4\Afform::get()->addWhere('name', '=', $directiveName)->execute();
+    $this->assertEquals($directiveName, $result[0]['name'], $message);
+    $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
+    $this->assertEquals($get($originalMetadata, 'description'), $get($result[0], 'description'), $message);
+    $this->assertEquals($get($originalMetadata, 'server_route'), $get($result[0], 'server_route'), $message);
+    $this->assertTrue(is_array($result[0]['layout']), $message);
 
     $message = 'After updating with Afform.create, the revised data should be returned';
     $result = Civi\Api4\Afform::update()
-      ->addWhere('name', '=', 'afformExamplepage')
+      ->addWhere('name', '=', $directiveName)
       ->addValue('description', 'The temporary description')
       ->execute();
-    $this->assertEquals('afformExamplepage', $result[0]['name'], $message);
+    $this->assertEquals($directiveName, $result[0]['name'], $message);
     $this->assertEquals('The temporary description', $result[0]['description'], $message);
 
     $message = 'After updating, the Afform.get API should return blended data';
-    $result = Civi\Api4\Afform::get()->addWhere('name', '=', 'afformExamplepage')->execute();
-    $this->assertEquals('afformExamplepage', $result[0]['name'], $message);
-    $this->assertEquals('', $result[0]['title'], $message);
-    $this->assertEquals('The temporary description', $result[0]['description'], $message);
-    $this->assertEquals('civicrm/example-page', $result[0]['server_route'], $message);
+    $result = Civi\Api4\Afform::get()->addWhere('name', '=', $directiveName)->execute();
+    $this->assertEquals($directiveName, $result[0]['name'], $message);
+    $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
+    $this->assertEquals('The temporary description', $get($result[0], 'description'), $message);
+    $this->assertEquals($get($originalMetadata, 'server_route'), $get($result[0], 'server_route'), $message);
     $this->assertTrue(is_array($result[0]['layout']), $message);
 
-    Civi\Api4\Afform::revert()->addWhere('name', '=', 'afformExamplepage')->execute();
-    $message = 'After reverting, te final Afform.get should return default data';
-    $result = Civi\Api4\Afform::get()->addWhere('name', '=', 'afformExamplepage')->execute();
-    $this->assertEquals('afformExamplepage', $result[0]['name'], $message);
-    $this->assertEquals('', $result[0]['title'], $message);
-    $this->assertEquals('', $result[0]['description'], $message);
-    $this->assertEquals('civicrm/example-page', $result[0]['server_route'], $message);
+    Civi\Api4\Afform::revert()->addWhere('name', '=', $directiveName)->execute();
+    $message = 'After reverting, the final Afform.get should return default data';
+    $result = Civi\Api4\Afform::get()->addWhere('name', '=', $directiveName)->execute();
+    $this->assertEquals($directiveName, $result[0]['name'], $message);
+    $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
+    $this->assertEquals($get($originalMetadata, 'description'), $get($result[0], 'description'), $message);
+    $this->assertEquals($get($originalMetadata, 'server_route'), $get($result[0], 'server_route'), $message);
     $this->assertTrue(is_array($result[0]['layout']), $message);
   }
 


### PR DESCRIPTION
__Before__: To create an afform, you *must* create both the HTML and JSON file.

__After__: To create an afform, you *must* create the HTML file. You *may* create JSON file.

__Comments__: This enhances developer usability. It also expands the test-case to cover some more variations in file-naming.