### PR TITLE
Afform API - For "layout" property, deeply parse Angular's JS-style fields

### DIFF
--- a/core/CRM/Afform/ArrayHtml.php
+++ b/core/CRM/Afform/ArrayHtml.php
@@ -13,10 +13,11 @@ class CRM_Afform_ArrayHtml {
   /**
    * @param array $array
    *   Ex: ['#tag' => 'div', 'class' => 'greeting', '#children' => ['Hello world']]
+   * @param string $format
    * @return string
    *   Ex: '<div class="greeting">Hello world</div>'
    */
-  public function convertArrayToHtml($array) {
+  public function convertArrayToHtml(array $array, $format = 'shallow') {
     if ($array === []) {
       return '';
     }
@@ -66,10 +67,11 @@ class CRM_Afform_ArrayHtml {
   /**
    * @param string $html
    *   Ex: '<div class="greeting">Hello world</div>'
+   * @param string $format
    * @return array
    *   Ex: ['#tag' => 'div', 'class' => 'greeting', '#children' => ['Hello world']]
    */
-  public function convertHtmlToArray($html) {
+  public function convertHtmlToArray($html, $format = 'shallow') {
     if ($html === '') {
       return [];
     }

--- a/core/Civi/Api4/Utils/AfformFormatTrait.php
+++ b/core/Civi/Api4/Utils/AfformFormatTrait.php
@@ -12,9 +12,9 @@ trait AfformFormatTrait {
 
   /**
    * @var string
-   *   Either 'array' or 'html'.
+   * @options html,shallow,deep
    */
-  protected $layoutFormat = 'array';
+  protected $layoutFormat = 'shallow';
 
   /**
    * @param string $html
@@ -22,18 +22,11 @@ trait AfformFormatTrait {
    * @throws \API_Exception
    */
   protected function convertHtmlToOutput($html) {
-    switch ($this->layoutFormat) {
-      case 'html':
-        return $html;
-
-      case 'array':
-      case NULL:
-        $converter = new \CRM_Afform_ArrayHtml();
-        return $converter->convertHtmlToArray($html);
-
-      default:
-        throw new \API_Exception("Requested format is unrecognized");
+    if ($this->layoutFormat === 'html') {
+      return $html;
     }
+    $converter = new \CRM_Afform_ArrayHtml();
+    return $converter->convertHtmlToArray($html, $this->layoutFormat);
   }
 
   /**
@@ -42,18 +35,11 @@ trait AfformFormatTrait {
    * @throws \API_Exception
    */
   protected function convertInputToHtml($mixed) {
-    switch ($this->layoutFormat) {
-      case 'html':
-        return $mixed;
-
-      case 'array':
-      case NULL:
-        $converter = new \CRM_Afform_ArrayHtml();
-        return $converter->convertArrayToHtml($mixed);
-
-      default:
-        throw new \API_Exception("Requested format is unrecognized");
+    if ($this->layoutFormat === 'html') {
+      return $mixed;
     }
+    $converter = new \CRM_Afform_ArrayHtml();
+    return $converter->convertArrayToHtml($mixed, $this->layoutFormat);
   }
 
 }

--- a/core/Civi/Api4/Utils/AfformFormatTrait.php
+++ b/core/Civi/Api4/Utils/AfformFormatTrait.php
@@ -25,8 +25,8 @@ trait AfformFormatTrait {
     if ($this->layoutFormat === 'html') {
       return $html;
     }
-    $converter = new \CRM_Afform_ArrayHtml();
-    return $converter->convertHtmlToArray($html, $this->layoutFormat);
+    $converter = new \CRM_Afform_ArrayHtml($this->layoutFormat === 'deep');
+    return $converter->convertHtmlToArray($html);
   }
 
   /**
@@ -38,8 +38,8 @@ trait AfformFormatTrait {
     if ($this->layoutFormat === 'html') {
       return $mixed;
     }
-    $converter = new \CRM_Afform_ArrayHtml();
-    return $converter->convertArrayToHtml($mixed, $this->layoutFormat);
+    $converter = new \CRM_Afform_ArrayHtml($this->layoutFormat === 'deep');
+    return $converter->convertArrayToHtml($mixed);
   }
 
 }

--- a/core/Civi/Api4/Utils/AfformFormatTrait.php
+++ b/core/Civi/Api4/Utils/AfformFormatTrait.php
@@ -14,7 +14,7 @@ trait AfformFormatTrait {
    * @var string
    * @options html,shallow,deep
    */
-  protected $layoutFormat = 'shallow';
+  protected $layoutFormat = 'deep';
 
   /**
    * @param string $html
@@ -25,7 +25,7 @@ trait AfformFormatTrait {
     if ($this->layoutFormat === 'html') {
       return $html;
     }
-    $converter = new \CRM_Afform_ArrayHtml($this->layoutFormat === 'deep');
+    $converter = new \CRM_Afform_ArrayHtml($this->layoutFormat !== 'shallow');
     return $converter->convertHtmlToArray($html);
   }
 
@@ -38,7 +38,7 @@ trait AfformFormatTrait {
     if ($this->layoutFormat === 'html') {
       return $mixed;
     }
-    $converter = new \CRM_Afform_ArrayHtml($this->layoutFormat === 'deep');
+    $converter = new \CRM_Afform_ArrayHtml($this->layoutFormat !== 'shallow');
     return $converter->convertArrayToHtml($mixed);
   }
 

--- a/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/mock/tests/phpunit/api/v4/AfformTest.php
@@ -1,8 +1,5 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
-
 /**
  * Afform.Get API Test Case
  * This is a generic test class implemented with PHPUnit.
@@ -66,13 +63,34 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
   public function getFormatExamples() {
     $es = [];
 
-    $asHtml = '<strong>New text!</strong>';
-    $asArray = ['#tag' => 'strong', '#children' => ['New text!']];
+    $asHtml = '<div><strong>New text!</strong><af-field field-name="do_not_sms" field-defn="{label: \'Do not do any of the emailing\'}"></af-field></div>';
+    $asShallow = [
+      '#tag' => 'div',
+      '#children' => [
+        ['#tag' => 'strong', '#children' => ['New text!']],
+        ['#tag' => 'af-field', 'field-name' => 'do_not_sms', 'field-defn' => "{label: 'Do not do any of the emailing'}"],
+      ],
+    ];
+    $asDeep = [
+      '#tag' => 'div',
+      '#children' => [
+        ['#tag' => 'strong', '#children' => ['New text!']],
+        ['#tag' => 'af-field', 'field-name' => 'do_not_sms', 'field-defn' => ['label' => 'Do not do any of the emailing']],
+      ],
+    ];
 
-    $es[] = ['fakelibBareFile', 'html', $asHtml, 'array', $asArray];
-    $es[] = ['fakelibBareFile', 'array', $asArray, 'html', $asHtml];
     $es[] = ['fakelibBareFile', 'html', $asHtml, 'html', $asHtml];
-    $es[] = ['fakelibBareFile', 'array', $asArray, 'array', $asArray];
+
+    $es[] = ['fakelibBareFile', 'html', $asHtml, 'shallow', $asShallow];
+    $es[] = ['fakelibBareFile', 'shallow', $asShallow, 'html', $asHtml];
+    $es[] = ['fakelibBareFile', 'shallow', $asShallow, 'shallow', $asShallow];
+
+    $es[] = ['fakelibBareFile', 'html', $asHtml, 'deep', $asDeep];
+    $es[] = ['fakelibBareFile', 'deep', $asDeep, 'html', $asHtml];
+    $es[] = ['fakelibBareFile', 'deep', $asDeep, 'deep', $asDeep];
+
+    $es[] = ['fakelibBareFile', 'shallow', $asShallow, 'deep', $asDeep];
+    $es[] = ['fakelibBareFile', 'deep', $asDeep, 'shallow', $asShallow];
 
     return $es;
   }

--- a/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/mock/tests/phpunit/api/v4/AfformTest.php
@@ -63,34 +63,16 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
   public function getFormatExamples() {
     $es = [];
 
-    $asHtml = '<div><strong>New text!</strong><af-field field-name="do_not_sms" field-defn="{label: \'Do not do any of the emailing\'}"></af-field></div>';
-    $asShallow = [
-      '#tag' => 'div',
-      '#children' => [
-        ['#tag' => 'strong', '#children' => ['New text!']],
-        ['#tag' => 'af-field', 'field-name' => 'do_not_sms', 'field-defn' => "{label: 'Do not do any of the emailing'}"],
-      ],
-    ];
-    $asDeep = [
-      '#tag' => 'div',
-      '#children' => [
-        ['#tag' => 'strong', '#children' => ['New text!']],
-        ['#tag' => 'af-field', 'field-name' => 'do_not_sms', 'field-defn' => ['label' => 'Do not do any of the emailing']],
-      ],
-    ];
-
-    $es[] = ['fakelibBareFile', 'html', $asHtml, 'html', $asHtml];
-
-    $es[] = ['fakelibBareFile', 'html', $asHtml, 'shallow', $asShallow];
-    $es[] = ['fakelibBareFile', 'shallow', $asShallow, 'html', $asHtml];
-    $es[] = ['fakelibBareFile', 'shallow', $asShallow, 'shallow', $asShallow];
-
-    $es[] = ['fakelibBareFile', 'html', $asHtml, 'deep', $asDeep];
-    $es[] = ['fakelibBareFile', 'deep', $asDeep, 'html', $asHtml];
-    $es[] = ['fakelibBareFile', 'deep', $asDeep, 'deep', $asDeep];
-
-    $es[] = ['fakelibBareFile', 'shallow', $asShallow, 'deep', $asDeep];
-    $es[] = ['fakelibBareFile', 'deep', $asDeep, 'shallow', $asShallow];
+    foreach (['apple', 'banana'] as $exampleName) {
+      $exampleFile = '/formatExamples/' . $exampleName . '.php';
+      $example = require __DIR__ . $exampleFile;
+      $formats = ['html', 'shallow', 'deep'];
+      foreach ($formats as $updateFormat) {
+        foreach ($formats as $readFormat) {
+          $es[] = ['fakelibBareFile', $updateFormat, $example[$updateFormat], $readFormat, $example[$readFormat], $exampleFile];
+        }
+      }
+    }
 
     return $es;
   }
@@ -110,9 +92,11 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
    *   'html' or 'array'
    * @param mixed $readLayout
    *   The value that we expect to read.
+   * @param string $exampleName
+   *   (For debug messages) A symbolic name of the example data-set being tested.
    * @dataProvider getFormatExamples
    */
-  public function testUpdateAndGetFormat($directiveName, $updateFormat, $updateLayout, $readFormat, $readLayout) {
+  public function testUpdateAndGetFormat($directiveName, $updateFormat, $updateLayout, $readFormat, $readLayout, $exampleName) {
     Civi\Api4\Afform::revert()->addWhere('name', '=', $directiveName)->execute();
 
     Civi\Api4\Afform::update()
@@ -126,7 +110,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
       ->setLayoutFormat($readFormat)
       ->execute();
 
-    $this->assertEquals($readLayout, $result[0]['layout']);
+    $this->assertEquals($readLayout, $result[0]['layout'], "Based on \"$exampleName\", writing content as \"$updateFormat\" and reading back as \"$readFormat\".");
 
     Civi\Api4\Afform::revert()->addWhere('name', '=', $directiveName)->execute();
   }

--- a/mock/tests/phpunit/api/v4/formatExamples/apple.php
+++ b/mock/tests/phpunit/api/v4/formatExamples/apple.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+  'html' => '<strong>New text!</strong>',
+  'shallow' => ['#tag' => 'strong', '#children' => ['New text!']],
+  'deep' => ['#tag' => 'strong', '#children' => ['New text!']],
+];

--- a/mock/tests/phpunit/api/v4/formatExamples/banana.php
+++ b/mock/tests/phpunit/api/v4/formatExamples/banana.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+  'html' => '<div><strong>New text!</strong><af-field field-name="do_not_sms" field-defn="{label: \'Do not do any of the emailing\'}"></af-field></div>',
+  'shallow' => [
+    '#tag' => 'div',
+    '#children' => [
+      ['#tag' => 'strong', '#children' => ['New text!']],
+      ['#tag' => 'af-field', 'field-name' => 'do_not_sms', 'field-defn' => "{label: 'Do not do any of the emailing'}"],
+    ],
+  ],
+  'deep' => [
+    '#tag' => 'div',
+    '#children' => [
+      ['#tag' => 'strong', '#children' => ['New text!']],
+      ['#tag' => 'af-field', 'field-name' => 'do_not_sms', 'field-defn' => ['label' => 'Do not do any of the emailing']],
+    ],
+  ],
+];


### PR DESCRIPTION
Note: The previous `layoutFormat=array` is replaced by two formats:

* `shallow` (as before; with JS values as literals)
* `deep` (with encoding+decoding of Angular's JS-style fields)