### PR TITLE
Do not fatal on missing extensions

### DIFF
--- a/core/CRM/Afform/AfformScanner.php
+++ b/core/CRM/Afform/AfformScanner.php
@@ -55,8 +55,13 @@ class CRM_Afform_AfformScanner {
     $mapper = CRM_Extension_System::singleton()->getMapper();
     foreach ($mapper->getModules() as $module) {
       /** @var $module CRM_Core_Module */
-      if ($module->is_active) {
-        $this->appendFilePaths($paths, dirname($mapper->keyToPath($module->name)) . DIRECTORY_SEPARATOR . 'ang', 20);
+      try {
+        if ($module->is_active) {
+          $this->appendFilePaths($paths, dirname($mapper->keyToPath($module->name)) . DIRECTORY_SEPARATOR . 'ang', 20);
+        }
+      }
+      catch (CRM_Extension_Exception_MissingException $e) {
+        // If the extension is missing skip & continue.
       }
     }
 


### PR DESCRIPTION
Currently a missing extension will lead to a complete fatal on afforms. We can ignore these in the
extensions, missing extensions are otherwise notified in corre