### PR TITLE
Automatically detect requirements in afforms

### DIFF
--- a/core/CRM/Afform/AfformScanner.php
+++ b/core/CRM/Afform/AfformScanner.php
@@ -134,7 +134,7 @@ class CRM_Afform_AfformScanner {
 
     $defaults = [
       'name' => $name,
-      'requires' => explode(',', self::DEFAULT_REQUIRES),
+      'requires' => [],
       'title' => '',
       'description' => '',
       'is_public' => FALSE,

--- a/core/Civi/Afform/Symbols.php
+++ b/core/Civi/Afform/Symbols.php
@@ -1,0 +1,68 @@
+<?php
+namespace Civi\Afform;
+
+class Symbols {
+
+  /**
+   * @var array
+   *   Array(string $element => int $count).
+   */
+  public $elements = [];
+
+  /**
+   * @var array
+   *   Array(string $class => int $count).
+   */
+  public $classes = [];
+
+  /**
+   * @var array
+   *   Array(string $attr => int $count).
+   */
+  public $attributes = [];
+
+  /**
+   * @param string $html
+   * @return static
+   */
+  public static function scan($html) {
+    $symbols = new static();
+    $doc = new \DOMDocumentWrapper($html, 'text/html');
+    $symbols->scanNode($doc->root);
+    return $symbols;
+  }
+
+  protected function scanNode(\DOMNode $node) {
+    if ($node instanceof \DOMElement) {
+
+      self::increment($this->elements, $node->tagName);
+
+      foreach ($node->childNodes as $childNode) {
+        $this->scanNode($childNode);
+      }
+
+      foreach ($node->attributes as $attribute) {
+        $this->scanNode($attribute);
+      }
+    }
+
+    elseif ($node instanceof \DOMAttr) {
+      self::increment($this->attributes, $node->nodeName);
+
+      if ($node->nodeName === 'class') {
+        $classes = explode(' ', $node->nodeValue);
+        foreach ($classes as $class) {
+          self::increment($this->classes, $class);
+        }
+      }
+    }
+  }
+
+  private static function increment(&$arr, $key) {
+    if (!isset($arr[$key])) {
+      $arr[$key] = 0;
+    }
+    $arr[$key]++;
+  }
+
+}

--- a/core/Civi/Afform/Symbols.php
+++ b/core/Civi/Afform/Symbols.php
@@ -50,12 +50,32 @@ class Symbols {
       self::increment($this->attributes, $node->nodeName);
 
       if ($node->nodeName === 'class') {
-        $classes = explode(' ', $node->nodeValue);
+        $classes = $this->parseClasses($node->nodeValue);
         foreach ($classes as $class) {
           self::increment($this->classes, $class);
         }
       }
     }
+  }
+
+  /**
+   * @param string $expr
+   *   Ex: 'crm-icon fa-mail'
+   * @return array
+   *   Ex: ['crm-icon', 'fa-mail']
+   */
+  protected function parseClasses($expr) {
+    if ($expr === '' || $expr === NULL || $expr === FALSE) {
+      return [];
+    }
+    if (strpos($expr, '{{') === FALSE) {
+      return explode(' ', $expr);
+    }
+    if (preg_match_all(';([a-zA-Z\-_]+|\{\{.*\}\}) ;U', "$expr ", $m)) {
+      return $m[1];
+    }
+    error_log("Failed to parse CSS classes: $expr");
+    return [];
   }
 
   private static function increment(&$arr, $key) {

--- a/core/Civi/Api4/Action/Afform/Update.php
+++ b/core/Civi/Api4/Action/Afform/Update.php
@@ -56,7 +56,7 @@ class Update extends BasicUpdateAction {
     }
 
     // We may have changed list of files covered by the cache.
-    $scanner->clear();
+    _afform_clear();
 
     if (isset($updates['server_route']) && $updates['server_route'] !== $orig[0]['server_route']) {
       \CRM_Core_Menu::store();

--- a/core/Civi/Api4/Afform.php
+++ b/core/Civi/Api4/Afform.php
@@ -40,7 +40,7 @@ class Afform extends AbstractEntity {
       }
 
       // We may have changed list of files covered by the cache.
-      $scanner->clear();
+      _afform_clear();
 
       // FIXME if `server_route` changes, then flush the menu cache.
       // FIXME if asset-caching is enabled, then flush the asset cache

--- a/core/afform.php
+++ b/core/afform.php
@@ -424,6 +424,18 @@ function afform_civicrm_alterMenu(&$items) {
 }
 
 /**
+ * Clear any local/in-memory caches based on afform data.
+ */
+function _afform_clear() {
+  $container = \Civi::container();
+  $container->get('afform_scanner')->clear();
+
+  // Civi\Angular\Manager doesn't currently have a way to clear its in-memory
+  // data, so we just reset the whole object.
+  $container->set('angular', NULL);
+}
+
+/**
  * @param string $fileBaseName
  *   Ex: foo-bar
  * @param string $format

--- a/core/afform.php
+++ b/core/afform.php
@@ -37,6 +37,7 @@ function _afform_fields_filter($params) {
  * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
  */
 function afform_civicrm_container($container) {
+  $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
   $container->setDefinition('afform_scanner', new \Symfony\Component\DependencyInjection\Definition(
     'CRM_Afform_AfformScanner',
     []
@@ -50,8 +51,15 @@ function afform_civicrm_container($container) {
  */
 function afform_civicrm_config(&$config) {
   _afform_civix_civicrm_config($config);
+
+  if (isset(Civi::$statics[__FUNCTION__])) {
+    return;
+  }
+  Civi::$statics[__FUNCTION__] = 1;
+
   // Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], -500);
   Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);
+  Civi::dispatcher()->addListener('hook_civicrm_angularModules', '_afform_civicrm_angularModules_autoReq', -1000);
 }
 
 /**
@@ -155,6 +163,7 @@ function afform_civicrm_caseTypes(&$caseTypes) {
 function afform_civicrm_angularModules(&$angularModules) {
   _afform_civix_civicrm_angularModules($angularModules);
 
+  /** @var CRM_Afform_AfformScanner $scanner */
   $scanner = Civi::service('afform_scanner');
   $names = array_keys($scanner->findFilePaths());
   foreach ($names as $name) {
@@ -164,6 +173,11 @@ function afform_civicrm_angularModules(&$angularModules) {
       'js' => ['assetBuilder://afform.js?name=' . urlencode($name)],
       'requires' => $meta['requires'],
       'basePages' => [],
+      'exports' => [
+        // Each afform is an attribute and an element.
+        'el' => [_afform_angular_module_name($name, 'dash')],
+        'attr' => [_afform_angular_module_name($name, 'dash')],
+      ],
     ];
 
     // FIXME: The HTML layout template is embedded in the JS asset.
@@ -171,6 +185,108 @@ function afform_civicrm_angularModules(&$angularModules) {
     // the normal workflow for templates (e.g. translation).
     // We should update core so that 'partials' can be specified more dynamically.
   }
+}
+
+/**
+ * Scan the list of Angular modules and inject automatic-requirements.
+ *
+ * TLDR: if an afform uses element "<other-el/>", and if another module defines
+ * `$angularModules['otherMod']['exports']['el'][0] === 'other-el'`, then
+ * the 'otherMod' is automatically required.
+ *
+ * @param \Civi\Core\Event\GenericHookEvent $e
+ * @see CRM_Utils_Hook::angularModules()
+ */
+function _afform_civicrm_angularModules_autoReq($e) {
+  /** @var CRM_Afform_AfformScanner $scanner */
+  $scanner = Civi::service('afform_scanner');
+  $moduleEnvId = md5(\CRM_Core_Config_Runtime::getId() . implode(',', array_keys($e->angularModules)));
+  $depCache = CRM_Utils_Cache::create([
+    'name' => 'afdep_' . substr($moduleEnvId, 0, 32 - 6),
+    'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
+    'withArray' => 'fast',
+    'prefetch' => TRUE,
+  ]);
+  $depCacheTtl = 2 * 60 * 60;
+
+  $revMap = _afform_reverse_deps($e->angularModules);
+
+  $formNames = array_keys($scanner->findFilePaths());
+  foreach ($formNames as $formName) {
+    $angModule = _afform_angular_module_name($formName, 'camel');
+    $cacheLine = $depCache->get($formName, NULL);
+
+    $jFile = $scanner->findFilePath($formName, 'aff.json');
+    $hFile = $scanner->findFilePath($formName, 'aff.html');
+
+    $jStat = stat($jFile);
+    $hStat = stat($hFile);
+
+    if ($cacheLine === NULL) {
+      $needsUpdate = TRUE;
+    }
+    elseif ($jStat !== FALSE && $jStat['size'] !== $cacheLine['js']) {
+      $needsUpdate = TRUE;
+    }
+    elseif ($jStat !== FALSE && $jStat['mtime'] > $cacheLine['jm']) {
+      $needsUpdate = TRUE;
+    }
+    elseif ($hStat !== FALSE && $hStat['size'] !== $cacheLine['hs']) {
+      $needsUpdate = TRUE;
+    }
+    elseif ($hStat !== FALSE && $hStat['mtime'] > $cacheLine['hm']) {
+      $needsUpdate = TRUE;
+    }
+    else {
+      $needsUpdate = FALSE;
+    }
+
+    if ($needsUpdate) {
+      $cacheLine = [
+        'js' => $jStat['size'] ?? NULL,
+        'jm' => $jStat['mtime'] ?? NULL,
+        'hs' => $hStat['size'] ?? NULL,
+        'hm' => $hStat['mtime'] ?? NULL,
+        'r' => array_values(array_unique(array_merge(
+          [CRM_Afform_AfformScanner::DEFAULT_REQUIRES],
+          $e->angularModules[$angModule]['requires'] ?? [],
+          _afform_reverse_deps_find($formName, file_get_contents($hFile), $revMap)
+        ))),
+      ];
+      // print_r(['cache update:' . $formName => $cacheLine]);
+      $depCache->set($formName, $cacheLine, $depCacheTtl);
+    }
+
+    $e->angularModules[$angModule]['requires'] = $cacheLine['r'];
+  }
+}
+
+/**
+ * @param $angularModules
+ * @return array
+ *   'attr': array(string $attrName => string $angModuleName)
+ *   'el': array(string $elementName => string $angModuleName)
+ */
+function _afform_reverse_deps($angularModules) {
+  $revMap = [];
+  foreach (['attr', 'el'] as $exportType) {
+    $revMap[$exportType] = [];
+    foreach (array_keys($angularModules) as $module) {
+      if (isset($angularModules[$module]['exports'][$exportType])) {
+        foreach ($angularModules[$module]['exports'][$exportType] as $exportItem) {
+          $revMap[$exportType][$exportItem] = $module;
+        }
+      }
+    }
+  }
+  return $revMap;
+}
+
+function _afform_reverse_deps_find($formName, $html, $revMap) {
+  $symbols = \Civi\Afform\Symbols::scan($html);
+  $elems = array_intersect_key($revMap['el'], $symbols->elements);
+  $attrs = array_intersect_key($revMap['attr'], $symbols->attributes);
+  return array_values(array_unique(array_merge($elems, $attrs)));
 }
 
 /**

--- a/core/ang/af.ang.php
+++ b/core/ang/af.ang.php
@@ -15,7 +15,8 @@ return [
   'settings' => [],
   'basePages' => [],
   'exports' => [
-    'el' => ['af-entity', 'af-fieldset', 'af-form'],
-    'attr' => ['af-entity', 'af-fieldset', 'af-form'],
+    'af-entity' => 'AE',
+    'af-fieldset' => 'AE',
+    'af-form' => 'AE',
   ],
 ];

--- a/core/ang/af.ang.php
+++ b/core/ang/af.ang.php
@@ -14,4 +14,8 @@ return [
   'requires' => ['crmUtil'],
   'settings' => [],
   'basePages' => [],
+  'exports' => [
+    'el' => ['af-entity', 'af-fieldset', 'af-form'],
+    'attr' => ['af-entity', 'af-fieldset', 'af-form'],
+  ],
 ];

--- a/core/ang/afBlock.ang.php
+++ b/core/ang/afBlock.ang.php
@@ -18,7 +18,7 @@ return [
   'settings' => [],
   'basePages' => [],
   'exports' => [
-    'el' => ['af-block-contact-name', 'af-block-contact-email'],
-    'attr' => ['af-block-contact-name', 'af-block-contact-email'],
+    'af-block-contact-name' => 'AE',
+    'af-block-contact-email' => 'AE',
   ],
 ];

--- a/core/ang/afBlock.ang.php
+++ b/core/ang/afBlock.ang.php
@@ -17,4 +17,8 @@ return [
   ],
   'settings' => [],
   'basePages' => [],
+  'exports' => [
+    'el' => ['af-block-contact-name', 'af-block-contact-email'],
+    'attr' => ['af-block-contact-name', 'af-block-contact-email'],
+  ],
 ];

--- a/core/ang/afField.ang.php
+++ b/core/ang/afField.ang.php
@@ -17,4 +17,8 @@ return [
   ],
   'settings' => [],
   'basePages' => [],
+  'exports' => [
+    'el' => ['af-field'],
+    'attr' => ['af-field'],
+  ],
 ];

--- a/core/ang/afField.ang.php
+++ b/core/ang/afField.ang.php
@@ -18,7 +18,6 @@ return [
   'settings' => [],
   'basePages' => [],
   'exports' => [
-    'el' => ['af-field'],
-    'attr' => ['af-field'],
+    'af-field' => 'AE',
   ],
 ];

--- a/core/tests/phpunit/Civi/Afform/SymbolsTest.php
+++ b/core/tests/phpunit/Civi/Afform/SymbolsTest.php
@@ -1,0 +1,103 @@
+<?php
+namespace Civi\Afform;
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  /**
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function getExamples() {
+    $exs = [];
+    $exs[] = [
+      '<div/>',
+      [
+        'e' => ['div' => 1, 'body' => 1],
+        'a' => [],
+        'c' => [],
+      ],
+    ];
+    $exs[] = [
+      '<my-tabset><my-tab id="1"/><my-tab id="2">foo</my-tab><my-tab id="3">bar</my-tab></my-tabset>',
+      [
+        'e' => ['my-tabset' => 1, 'my-tab' => 3, 'body' => 1],
+        'a' => ['id' => 3],
+        'c' => [],
+      ],
+    ];
+    $exs[] = [
+      '<div class="my-parent"><div class="my-child"><img class="special" src="foo.png"/></div></div>',
+      [
+        'e' => ['div' => 2, 'img' => 1, 'body' => 1],
+        'a' => ['class' => 3, 'src' => 1],
+        'c' => [
+          'my-parent' => 1,
+          'my-child' => 1,
+          'special' => 1,
+        ],
+      ],
+    ];
+    $exs[] = [
+      '<div class="my-parent foo bar">a<div class="my-child whiz bang {{ghost + stuff}} last">b</div>c</div>',
+      [
+        'e' => ['div' => 2, 'body' => 1],
+        'a' => ['class' => 2],
+        'c' => [
+          'my-parent' => 1,
+          'my-child' => 1,
+          'foo' => 1,
+          'bar' => 1,
+          'whiz' => 1,
+          'bang' => 1,
+          '{{ghost + stuff}}' => 1,
+          'last' => 1,
+        ],
+      ],
+    ];
+    $exs[] = [
+      '<div class="{{make[\'cheese\']}} {{ghost + stuff}} {{a}}_{{b}}"/>',
+      [
+        'e' => ['div' => 1, 'body' => 1],
+        'a' => ['class' => 1],
+        'c' => [
+          '{{ghost + stuff}}' => 1,
+          '{{make[\'cheese\']}}' => 1,
+          '{{a}}_{{b}}' => 1,
+        ],
+      ],
+    ];
+
+    return $exs;
+  }
+
+  /**
+   * @param string $html
+   * @param array $expect
+   *   List of expected symbol counts, by type.
+   *   Types are (e)lement, (a)ttribute, (c)lass
+   * @dataProvider getExamples
+   */
+  public function testSymbols($html, $expect) {
+    $expectDefaults = ['e' => [], 'a' => [], 'c' => []];
+    $expect = array_merge($expectDefaults, $expect);
+    $actual = Symbols::scan($html);
+
+    $this->assertEquals($expect['e'], $actual->elements);
+    $this->assertEquals($expect['a'], $actual->attributes);
+    $this->assertEquals($expect['c'], $actual->classes);
+  }
+
+}

--- a/html/ang/afHtmlAdmin.aff.json
+++ b/html/ang/afHtmlAdmin.aff.json
@@ -1,5 +1,4 @@
 {
   "title": "Afform HTML Administration",
-  "server_route": "civicrm/admin/afform-html",
-  "requires":["afCore", "afMoncao", "afHtmlEditor", "afHtmlList"]
+  "server_route": "civicrm/admin/afform-html"
 }

--- a/html/ang/afHtmlEditor.aff.json
+++ b/html/ang/afHtmlEditor.aff.json
@@ -1,4 +1,3 @@
 {
-  "title": "Afform HTML Editor",
-  "requires":["afCore", "afMoncao"]
+  "title": "Afform HTML Editor"
 }

--- a/html/ang/afHtmlList.aff.json
+++ b/html/ang/afHtmlList.aff.json
@@ -1,4 +1,3 @@
 {
-  "title": "Afform HTML List",
-  "requires":["afCore"]
+  "title": "Afform HTML List"
 }

--- a/html/ang/afMonaco.ang.php
+++ b/html/ang/afMonaco.ang.php
@@ -6,12 +6,12 @@
 return array(
   'js' => [
     AFFORM_HTML_MONACO . '/loader.js',
-    'ang/afMoncao.js',
-    //    'ang/afMoncao/*.js',
-    //    'ang/afMoncao/*/*.js',
+    'ang/afMonaco.js',
+    //    'ang/afMonaco/*.js',
+    //    'ang/afMonaco/*/*.js',
   ],
-  'css' => ['ang/afMoncao.css'],
-  // 'partials' => ['ang/afMoncao'],
+  'css' => ['ang/afMonaco.css'],
+  // 'partials' => ['ang/afMonaco'],
   'requires' => ['crmUi', 'crmUtil'],
   'settings' => [
     'paths' => [

--- a/html/ang/afMonaco.css
+++ b/html/ang/afMonaco.css
@@ -1,0 +1,4 @@
+/* Add any CSS rules for Angular module "afMonaco" */
+.af-monaco-container {
+    border:1px solid grey;
+}

--- a/html/ang/afMonaco.js
+++ b/html/ang/afMonaco.js
@@ -1,9 +1,9 @@
 (function(angular, $, _) {
-  angular.module('afMoncao', CRM.angRequires('afMoncao'));
+  angular.module('afMonaco', CRM.angRequires('afMonaco'));
 
   // "afMonaco" is a basic skeletal directive.
   // Example usage: <div af-monaco ng-model="my.content"></div>
-  angular.module('afMoncao').directive('afMonaco', function($timeout) {
+  angular.module('afMonaco').directive('afMonaco', function($timeout) {
     return {
       restrict: 'AE',
       require: 'ngModel',
@@ -11,7 +11,7 @@
       link: function($scope, $el, $attr, ngModel) {
         var heightPct = 0.70;
         var editor;
-        require.config({paths: CRM.afMoncao.paths});
+        require.config({paths: CRM.afMonaco.paths});
         require(['vs/editor/editor.main'], function() {
           var editorEl = $el.find('.af-monaco-container');
           editorEl.css({height: Math.round(heightPct * $(window).height())});

--- a/html/ang/afMoncao.ang.php
+++ b/html/ang/afMoncao.ang.php
@@ -20,6 +20,6 @@ return array(
   ],
   'basePages' => [],
   'exports' => [
-    'attr' => ['af-monaco'],
+    'af-monaco' => 'A',
   ],
 );

--- a/html/ang/afMoncao.ang.php
+++ b/html/ang/afMoncao.ang.php
@@ -19,4 +19,7 @@ return array(
     ],
   ],
   'basePages' => [],
+  'exports' => [
+    'attr' => ['af-monaco'],
+  ],
 );

--- a/html/ang/afMoncao.css
+++ b/html/ang/afMoncao.css
@@ -1,4 +1,0 @@
-/* Add any CSS rules for Angular module "afMoncao" */
-.af-monaco-container {
-    border:1px solid grey;
-}

--- a/mock/ang/mockPage.aff.json
+++ b/mock/ang/mockPage.aff.json
@@ -1,1 +1,1 @@
-{"server_route": "civicrm/mock-page", "requires":["mockFoo", "mockBareFile"]}
+{"server_route": "civicrm/mock-page", "requires":["extraMock"]}

--- a/mock/ang/testAfform.aff.json
+++ b/mock/ang/testAfform.aff.json
@@ -1,7 +1,4 @@
 {
   "server_route": "civicrm/test-afform",
-  "title": "This is a test",
-  "requires": [
-    "af", "afBlock", "afField", "afCore"
-  ]
+  "title": "This is a test"
 }


### PR DESCRIPTION
This PR addresses a significant usability issue when mixing elements from different modules.

## Example

Suppose you have two forms:

* `subPartEx.aff.html`: `<strong>I am the inner content!</strong>`
* `fullDocEx.aff.html`: `<p>Please embed <sub-part-ex/></p>`

## Before

To make the example work, you need to edit `fullDocEx.aff.json` to set the `requires` list to include `subPartEx`.

## After

You do not need to explicitly declare a dependency from `fullDocEx` to `subPartEx` - it's inferred automatically based on the current content of `fullDocEx.aff.html`.

The default/effective/auto-generated meta-data looks like this:

```php
$angularModules['subPartEx'] = [
  'requires' => ['afCore'],
  'exports' => ['sub-part-ex' => 'AE'],
];
$angularModules['fullDocEx'] = [
  'requires' => ['afCore', 'subPartEx'],
  'exports' => ['full-doc-ex' => 'AE'],
];
```

Observe that:

* All afforms automatically declare an `exports` list (with any HTML elements or HTML attributes).
* The content of `fullDocEx.aff.html` references `<sub-part-ex/>`, which is exported by `subPartEx`, so `fullDocEx` automatically requires `subPartEx`.

## Comments

* ~~This is flagged WIP because I need to add some unit-tests.~~ *Added tests*
* ~~I'm pretty tempted to remove support for storing the `requires` list in forked-copies of the form.~~ *Kept it in case one needs oddball services, but dialed it back so that it's not actually used/needed in most cases.*
* We should probably update the docs for `$angularModules` to mention the `exports` directive? 
* ~~Also, we may want to change the format to more closely match the AngularJS code (e.g. `subPartEx => AE`...)~~ *Done*
